### PR TITLE
readme db設計　修正完了

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Things you may want to cover:
 
 * Configuration
 
-* Database creation
+* Database creation   以下参照
 
 * Database initialization
 
@@ -23,13 +23,14 @@ Things you may want to cover:
 
 * ...
 
-以下DB設計を書く
+
+
 
 
 ## usersテーブル
-|Column|Type|Options|
-|------|----|-------|
-|nickname|string|null: false|
+|Column----|Type------|Options---|
+|----------|----------|----------|
+|nickname--|string----|null: false|
 |email|string|null: false, unique: true|
 |last_name|string|null: false|
 |first_name|string|null: false|
@@ -39,26 +40,30 @@ Things you may want to cover:
 |profile|text|-------|
 ### Association
 - has_one :profile, dependent: :destroy
+- has_one :credit
+<!-- アソシエーションが1対1の関係の時は、どちらかをhas_one、もう一方をbelongs_toにする。 -->
 - has_many :creditcards, dependent: :destroy
 - has_many :items, dependent: :destroy
 - has_many :comments, dependent: :destroy
 - has_many :likes, dependent: :destroy
 - has_many :solditems, dependent: :destroy
 
+
 ## addressesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|postcode|string|-------|
-|prefecture|string|-------|
-|municipality|string|-------|
-|address|string|-------|
-|room_number|string|-------|
-|phone|integer|-------|
-|user_id|integer|null: false, foreign_key: true|
+|Column---------|Type-----------|Options--------|
+|---------------|---------------|---------------|
+|postcode-------|string---------|null: false----|
+|prefecture-----|string---------|null: false----|
+|municipality---|string---------|null: false----|
+|address--------|string---------|null: false----|
+|room_number----|string---------|---------------|
+|phone----------|integer--------|null: false----|
+|user_id--------|integer--------|null: false, foreign_key: true|    /  references
 ### Association
 - belongs_to :user
 
-## creditcardsテーブル
+
+<!-- ## creditcardsテーブル   ※DBではなくpay.jpにて管理
 |Column|Type|Options|
 |------|----|-------|
 |cardnumber|integer|null: false, unique: true|
@@ -66,37 +71,50 @@ Things you may want to cover:
 |securitycode|integer|null: false|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
-- belongs_to :user
+- belongs_to :user -->
 
-## itemsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|name|string|null: false|
-|explanation|text|null: false|
-|brand|string|-------|
-|condition|string|null: false|
-|postage|integer|null: false|
-|area|string|null: false|
-|days|integer|null: false|
-|price|integer|null: false|
-|user_id|integer|null: false, foreign_key: true|
-|status|integer|null: false|
+※セキュリティの観点から、クレジットカードの番号やCVCをDBに保存してはいけない。
+ そのため、payjpにて生成される、customer_id(永続利用)を保存する
+## creditテーブル
+|Column---------|Type-----------|Options--------|
+|---------------|---------------|---------------|
+|user_id--------|integer--------|null: false, foreign_key: true|    /  references
+|customer_id----|---------------|---------------|  ※pay.jpの永続利用
 ### Association
 - belongs_to :user
+
+
+## itemsテーブル
+|Column---------|Type-----------|Options--------|
+|---------------|---------------|---------------|
+|name-----------|string---------|null: false----|
+|explanation----|text-----------|null: false----|
+|brand----------|string---------|---------------|
+|condition------|string---------|null: false----|
+|postage--------|integer--------|null: false----|
+|area-----------|string---------|null: false----|
+|days-----------|integer--------|null: false----|
+|price----------|integer--------|null: false----|
+|user_id--------|integer--------|null: false, foreign_key: true|    /  references
+|category_id----|integer--------|null: false, foreign_key: true|    /  references
+|status---------|integer--------|null: false----|
+### Association
+- belongs_to :user
+- belongs_to :category
 - has_one :solditem, dependent: :destroy
 - has_many :itemimages, dependent: :destroy
 - has_many :comments, dependent: :destroy
 - has_many :likes, dependent: :destroy
-- has_many :item_categories, dependent: :destroy
-- has_many :categories, through: :item_categories
+
 
 ## itemimagesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |image|string|null: false|
-|item_id|string|null: false, foreign_key: true|
+|item_id|string|null: false, foreign_key: true|     /  references
 ### Association
 - belongs_to :item
+
 
 ## solditemsテーブル
 |Column|Type|Options|
@@ -107,40 +125,44 @@ Things you may want to cover:
 - belongs_to :item
 - belongs_to :user
 
-## categoriesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|name|string|null: false|
-|ancestory|string|-------|
-### Association
-- has_many :item_categories ,dependent: :destroy
-- has_many :items, through: :item_categories
-- has_ancestry
 
-## item_categoriesテーブル
+## categoriesテーブル
+|Column---------|Type------------|Options--------|
+|---------------|----------------|---------------|
+|name-----------|string----------|null: false, index: true|
+|ancestory------|string----------|親子関係---------|
+### Association
+- has_many :items ,dependent: :destroy
+- has_ancestry
+<!-- ancestryはジェムの追加をあわせて行う（エラーが出る為） -->
+
+
+<!-- ## item_categoriesテーブル    ※ gem'ancestory'を使用する場合は中間テーブル不要
 |Column|Type|Options|
 |------|----|-------|
 |category_id|string|null: false, foreign_key: true|
 |item_id|string|null: false, foreign_key: true|
 ### Association
 - belongs_to :item
-- belongs_to :category
+- belongs_to :category -->
+
 
 ## commentsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|item_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|item_id|integer|null: false, foreign_key: true|    /  references
+|user_id|integer|null: false, foreign_key: true|    /  references
 |comment|text|null: false|
 ### Association
 - belongs_to :item
 - belongs_to :user
 
+
 ## likesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|item_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|item_id|integer|null: false, foreign_key: true|    /  references
+|user_id|integer|null: false, foreign_key: true|    /  references
 ### Association
 - belongs_to :item
 - belongs_to :user


### PR DESCRIPTION
# What
Pay.jp導入とAncestory実装に向けて、DBの設計を変更いたします。

# Why
上記導入と実装に合わない設計となっていた為

以下詳細(trello)


## ①クレジットカードのテーブル
クレジットカード等の重要情報は、原則DB上には保存しない。DBでテーブルを作成しない代わりに、payjpを用いて管理を行う。
→readmeにて、クレジットカードテーブルの削除
→payjpの仕様確認
Qiita最新: https://qiita.com/tanaka-t/items/99b722ab3be471d43183
pay.jplogin: https://pay.jp/
→メンバーへのプレゼン後、導入


## ②カテゴリ管理
アンセストリーを用いたカテゴリ管理では、item とcategory は1対多の関係となる。中間テーブルは不要となる。
GitHub:    https://github.com/stefankroes/ancestry
Qiita最新: https://qiita.com/KOKEINTER/items/f61323552b1cc793f316
Qiita最新: https://qiita.com/Sotq_17/items/120256209993fb05ebac
→readmeにて、１対多の構造に変更
→ancestryの仕様確認
→メンバーへの共有


## ③アドレス(住所)テーブルの制約付け
アドレス情報は抜けがあるとサービスに支障が出る可能性があるので、not nullを活用する。
→addressesのreadme記述変更 


## ④実際のDB設計を上記まとめて修正
→Migrateは全員のローカル環境に関わるところなので、声掛けしながら変更を行う。本番環境でのエラーも怖いので、月曜が近い場合は早めに確認する。
参考: https://hackmd.io/@gdHkuuFdTwqySPtsm8mzkA/BJJpg8vHH
参考: https://qiita.com/Sotq_17/items/120256209993fb05ebac