### PR TITLE
addressに送付先氏名・ふりがなを追加

### DIFF
--- a/app/assets/stylesheets/registrations.scss
+++ b/app/assets/stylesheets/registrations.scss
@@ -442,6 +442,110 @@
             }
           }
         }
+        .input-names2{
+          margin: 0 auto;
+          justify-content: center;
+          background-color: white;
+    
+          .names{
+            margin: 0 auto;
+            justify-content: center;
+            width: 400px;
+    
+            .name1{
+              .title{
+                display: flex;
+                padding: 5px 0;
+                span {
+                  color: red;
+                  font-weight: bold;
+                  font-size: 14px;
+                }
+              }
+              .character-name{
+                justify-content: space-between;
+                display: flex;
+                margin: 0 24px;
+                .first{
+                  width: 165.5px;
+                  height: 48px;
+                  .first--input{
+                    width: 165.5px;
+                    height: 48px;
+                    .user_first_name input{
+                      padding: 10px 16px 8px;
+                      width: 165.5px;
+                      height: 48px;
+                      border-radius: 4px;
+                      border: 1px solid #ccc
+                    }
+                  }
+                }
+                .last{
+                  width: 165.5px;
+                  height: 48px;
+                  .last--input{
+                    width: 165.5px;
+                    height: 48px;
+                    .user_last_name input{
+                      padding: 10px 16px 8px;
+                      width: 165.5px;
+                      height: 48px;
+                      border-radius: 4px;
+                      border: 1px solid #ccc
+                    }
+                  }
+                }
+              }
+            }
+            .name2{
+              .title{
+                display: flex;
+                padding: 5px 0;
+                span {
+                  color: red;
+                  font-weight: bold;
+                  font-size: 14px;
+                }
+              }
+              .kana-name{
+                justify-content: space-between;
+                display: flex;
+                margin: 0 24px;
+                .first{
+                  width: 165.5px;
+                  height: 48px;
+                  .first--input{
+                    width: 165.5px;
+                    height: 48px;
+                    .user_first_name_kana input{
+                      padding: 10px 16px 8px;
+                      width: 165.5px;
+                      height: 48px;
+                      border-radius: 4px;
+                      border: 1px solid #ccc
+                    }
+                  }
+                }
+                .last{
+                  width: 165.5px;
+                  height: 48px;
+                  .last--input{
+                    width: 165.5px;
+                    height: 48px;
+                    .user_last_name_kana input{
+                      padding: 10px 16px 8px;
+                      width: 165.5px;
+                      height: 48px;
+                      border-radius: 4px;
+                      border: 1px solid #ccc
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
         .phone{
           &__title{
             display: flex;

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -18,7 +18,7 @@ class AddressesController < ApplicationController
 
   private
   def address_params
-    params.require(:address).permit(:postcode,:prefecture,:municipality,:address,:room_number,:phone)
+    params.require(:address).permit(:postcode,:prefecture,:municipality,:address,:room_number,:sendname_first,:sendname_last,:sendname_first_kana,:sendname_last_kana,:phone)
   end
 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,11 @@ class ApplicationController < ActionController::Base
                                                                             :municipality,
                                                                             :address,
                                                                             :room_number,
-                                                                            :phone]])
+                                                                            :phone,
+                                                                            :sendname_first,
+                                                                            :sendname_last,
+                                                                            :sendname_first_kana,
+                                                                            :sendname_last_kana]])
   end
 
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,9 +12,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   # POST /resource
-  def create
-    super
-  end
+  # def create
+  #   super
+  # end
 
   # GET /resource/edit
   # def edit

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -6,13 +6,19 @@ class Address < ApplicationRecord
   # devise :database_authenticatable, :registerable,
   #        :recoverable, :rememberable, :validatable
 
+  VALID_HIRAGANA_REGEX = /\A[\p{hiragana}\p{blank}ー－]+\z/
+  VALID_ZENKAKU_REGEX = /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/
+
   validates :postcode, presence: true
   validates :postcode, format: { with: /\A\d{7}\z/ }
 
   validates :prefecture, presence: true
   validates :municipality, presence: true
   validates :address, presence: true
-
+  validates :sendname_first, presence: true, format: { with: VALID_ZENKAKU_REGEX }
+  validates :sendname_last, presence: true, format: { with: VALID_ZENKAKU_REGEX }
+  validates :sendname_first_kana, presence: true, format: { with: VALID_HIRAGANA_REGEX }
+  validates :sendname_last_kana, presence: true, format: { with: VALID_HIRAGANA_REGEX }
 
 
   VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -37,6 +37,32 @@
               .apartment__input
                 = f.text_field :room_number
                 
+          .input-names2
+            .names
+              .name1
+                .title
+                  %p 送付先お名前（全角）
+                .character-name
+                  .first
+                    .first--input
+                      .user_first_name
+                        =f.text_field :sendname_first, placeholder:" 例）振間" 
+                  .last
+                    .last--input
+                      .user_last_name
+                        =f.text_field :sendname_last, placeholder:" 例）太郎" 
+              .name2
+                .title
+                  %p  送付先お名前かな（全角）
+                .kana-name
+                  .first
+                    .first--input
+                      .user_first_name_kana                
+                        =f.text_field :sendname_first_kana, placeholder:" 例）ふりま" 
+                  .last
+                    .last--input 
+                      .user_last_name_kana
+                        =f.text_field :sendname_last_kana, placeholder:" 例）たろう" 
 
           .phone
             .phone__title

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,7 +25,6 @@
             .box1
               %br/
               = f.text_field :nickname, autofocus: true, autocomplete: "nickname", placeholder:" 6文字以下の任意"
-
         .mailaddress
           .field
             .title
@@ -175,6 +174,44 @@
                 = f.fields_for :address do |i| 
                   = i.text_field :room_number, placeholder:" 例）アジアビル" 
                 
+          .input-names2
+            .names
+              .name1
+                .title
+                  %p 　送付先お名前（全角）
+                  - if resource.errors.full_messages.include?("Address sendname firstを入力してください") || resource.errors.full_messages.include?("Address sendname lastを入力してください")
+                    %span= "　入力必須!"
+                  - if resource.errors.full_messages.include?("Address sendname firstは不正な値です") || resource.errors.full_messages.include?("Address sendname lastは不正な値です")
+                    %span= "　入力不正!"
+                .character-name
+                  .first
+                    .first--input
+                      .user_first_name
+                        = f.fields_for :address do |i|               
+                          =i.text_field :sendname_first, placeholder:" 例）振間" 
+                  .last
+                    .last--input
+                      .user_last_name
+                        = f.fields_for :address do |i|               
+                          =i.text_field :sendname_last, placeholder:" 例）太郎" 
+              .name2
+                .title
+                  %p  　送付先お名前かな（全角）
+                  - if resource.errors.full_messages.include?("Address sendname first kanaを入力してください") || resource.errors.full_messages.include?("Address sendname last kanaを入力してください")
+                    %span= "　入力必須!"
+                  - if resource.errors.full_messages.include?("Address sendname first kanaは不正な値です") || resource.errors.full_messages.include?("Address sendname last kanaは不正な値です")
+                    %span= "　入力不正!"
+                .kana-name
+                  .first
+                    .first--input
+                      .user_first_name_kana
+                        = f.fields_for :address do |i|               
+                          =i.text_field :sendname_first_kana, placeholder:" 例）ふりま" 
+                  .last
+                    .last--input 
+                      .user_last_name_kana
+                        = f.fields_for :address do |i|               
+                          =i.text_field :sendname_last_kana, placeholder:" 例）たろう" 
 
           .phone
             .phone__title

--- a/db/migrate/20200325100613_add_sendname_first_to_addresses.rb
+++ b/db/migrate/20200325100613_add_sendname_first_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddSendnameFirstToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :sendname_first, :string, null: false
+  end
+end

--- a/db/migrate/20200325100814_add_sendname_last_to_addresses.rb
+++ b/db/migrate/20200325100814_add_sendname_last_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddSendnameLastToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :sendname_last, :string, null: false
+  end
+end

--- a/db/migrate/20200325100909_add_sendname_first_kana_to_addresses.rb
+++ b/db/migrate/20200325100909_add_sendname_first_kana_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddSendnameFirstKanaToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :sendname_first_kana, :string, null: false
+  end
+end

--- a/db/migrate/20200325100928_add_sendname_last_kana_to_addresses.rb
+++ b/db/migrate/20200325100928_add_sendname_last_kana_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddSendnameLastKanaToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :sendname_last_kana, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_18_050332) do
+ActiveRecord::Schema.define(version: 2020_03_25_100928) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postcode", null: false
@@ -22,6 +22,10 @@ ActiveRecord::Schema.define(version: 2020_03_18_050332) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sendname_first", null: false
+    t.string "sendname_last", null: false
+    t.string "sendname_first_kana", null: false
+    t.string "sendname_last_kana", null: false
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -68,8 +72,8 @@ ActiveRecord::Schema.define(version: 2020_03_18_050332) do
     t.integer "user_id", null: false
     t.integer "category_id", null: false
     t.integer "status"
-    t.datetime "created_at.strftime("%Y-%m-%d %H:%M")", null: false
-    t.datetime "updated_at.strftime("%Y-%m-%d %H:%M")", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -82,8 +86,8 @@ ActiveRecord::Schema.define(version: 2020_03_18_050332) do
   create_table "solditems", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "item_id", null: false
     t.string "user_id", null: false
-    t.datetime "created_at.strftime("%Y-%m-%d %H:%M")", null: false
-    t.datetime "updated_at.strftime("%Y-%m-%d %H:%M")", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# What
[Issues②]
新規登録ページ、登録住所編集ページに下記項目を追加。
・送付先氏名
・送付先氏名のふりがな

addressテーブルに、カラムを4つ作成。データも登録される。
(sendname_first,sendname_last,sendname_first_kana,sendname_last_kana)

バリデーションも設定している。
（ふりがな欄に、平仮名以外は不可など）