### PR TITLE
小林/購入リクエストのブラウザバッティングを防止する

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -204,14 +204,14 @@ class ItemsController < ApplicationController
   end
 
   def pay
-    card = Credit.find_by(user_id: current_user.id)
-    Payjp.api_key = Rails.application.credentials[:PAYJP_SECRET_KEY]
-    Payjp::Charge.create(
-      amount: @item.price,
-      customer: card.customer_id,
-      currency: 'jpy'
-    )
     if @item.status == 1
+      card = Credit.find_by(user_id: current_user.id)
+      Payjp.api_key = Rails.application.credentials[:PAYJP_SECRET_KEY]
+      Payjp::Charge.create(
+        amount: @item.price,
+        customer: card.customer_id,
+        currency: 'jpy'
+      )
       @item.update( status: 0)
       solditem = Solditem.new( item_id: params[:id], user_id: current_user.id )
       solditem.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -211,11 +211,14 @@ class ItemsController < ApplicationController
       customer: card.customer_id,
       currency: 'jpy'
     )
-    @item.update( status: 0)
-    solditem = Solditem.new( item_id: params[:id], user_id: current_user.id )
-    solditem.save
-
-    redirect_to done_items_path(@item)
+    if @item.status == 1
+      @item.update( status: 0)
+      solditem = Solditem.new( item_id: params[:id], user_id: current_user.id )
+      solditem.save
+      redirect_to done_items_path(@item)
+    else
+      redirect_to item_path(@item), notice: "申し訳ありません！たった今、売り切れてしまいました"
+    end
   end
 
   def done


### PR DESCRIPTION
# What
複数のユーザーが自身のブラウザで同時タイミングで購入してしまった際に、僅差で遅れて購入ボタンを押したユーザーの購入を無効にし、「売り切れました」とバリデーションメッセージを表示する。

# What
購入/支払いトラブルを無くすため